### PR TITLE
Feature/add otb support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Changlelog
+# ChangeLog
+
+## [1.0.8] - 2018-08-01
+- Added support for One Time Binding on NgClass
 
 ## [1.0.1] - 2016-04-08
 - Use babel and ava instead of mocha

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usedcss",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Extract only styles presented in your html files.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -94,12 +94,14 @@ module.exports = postcss.plugin('usedcss', (options) => {
                   let cls = [];
                   let ngcl = html(el).attr('ng-class');
                   if (ngcl) {
+                    ngcl = ngcl.replace('::','');
                     cls = cls.concat(
                       Object.keys(expressions.compile(ngcl)())
                     );
                   }
                   let datang = html(el).attr('data-ng-class');
                   if (datang) {
+                    datang = datang.replace('::', '');
                     cls = cls.concat(
                       Object.keys(expressions.compile(datang)())
                     );

--- a/tests/main.tests.js
+++ b/tests/main.tests.js
@@ -14,7 +14,7 @@ test('Should remove unused css classes', t => {
 
 
 test('Should save ng-class classes', t => {
-  return runTest({ngclass: true}).then(result => {
+  return runTest({ngclass: true, html: 'test.html'}).then(result => {
     t.is(result.css,
       '.test1 .test2 { color: red }\n' +
       '.test10,.test2 { color: pink; }\n' +
@@ -22,6 +22,19 @@ test('Should save ng-class classes', t => {
       '.test2::before { content: \'\'; }\n' +
       '.test1 .test3 { color: white; }\n' +
       '.test1 .test4 { color: orange; }\n'
+    );
+  });
+});
+
+test('Should save ng-class classes with One Time Binding', t => {
+  return runTest({ngclass: true, html: 'ngClassOtb.html'}).then(result => {
+    t.is(result.css,
+      '.test1 .test2 { color: red }\n' +
+      '.test10,.test2 { color: pink; }\n' +
+      '.test1:after { content: \'\'; }\n' +
+      '.test2::before { content: \'\'; }\n' +
+      '.test1 .test4 { color: orange; }\n' +
+      '.test1 .test5 { color: magenta; }\n'
     );
   });
 });

--- a/tests/ngClassOtb.html
+++ b/tests/ngClassOtb.html
@@ -1,0 +1,4 @@
+<div class="test1">
+  <div class="test2" ng-class="::{'test5': 'fdsfsfsfs'}"></div>
+  <div class="test2" data-ng-class="::{'test4': 'fdsfsfsfs'}"></div>
+</div>


### PR DESCRIPTION
Background: On current implementation an error is triggered when One Time Binding is detected on NgClasses (https://docs.angularjs.org/guide/expression#one-time-binding)

Fix: detect when ng-class contain OTB syntax `ng-class"::{'class1': expression }"` and clean string before compile step. `ng-class"{'class1': expression }"`